### PR TITLE
updates and fixes for Beat Saber 1.37.5 

### DIFF
--- a/DiscordCore.csproj
+++ b/DiscordCore.csproj
@@ -127,6 +127,7 @@
     <Compile Include="DiscordManager.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UI\SettingsMenuManager.cs" />
     <Compile Include="UI\Settings.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DiscordManager.cs
+++ b/DiscordManager.cs
@@ -135,8 +135,6 @@ namespace DiscordCore
             try
             {
                 DiscordClient.Enable();
-                BSMLSettings.instance.RemoveSettingsMenu(Settings.instance);
-                BSMLSettings.instance.AddSettingsMenu("Discord Core", "DiscordCore.UI.SettingsViewController.bsml", Settings.instance);
             }
             catch (ResultException e)
             {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -18,6 +18,8 @@ namespace DiscordCore
 
             manager = new GameObject("DiscordManager");
             manager.AddComponent<DiscordManager>();
+
+            SettingsMenuManager.Initialize();
         }
 
         [OnEnable]

--- a/UI/Settings.cs
+++ b/UI/Settings.cs
@@ -54,7 +54,7 @@ namespace DiscordCore.UI
                             modObjectsList.Add(listObject);
                         }
 
-                        modsList.tableView.ReloadData();
+                        modsList.TableView.ReloadData();
                     }
                     else
                     {

--- a/UI/Settings.cs
+++ b/UI/Settings.cs
@@ -156,6 +156,7 @@ namespace DiscordCore.UI
             public void Refresh(bool selected, bool highlighted)
             {
                 modName.text = modInstance.settings.modName;
+                modIcon.gameObject.SetActive(modInstance.settings.modIcon != null);
                 modIcon.sprite = modInstance.settings.modIcon;
             }
 

--- a/UI/SettingsMenuManager.cs
+++ b/UI/SettingsMenuManager.cs
@@ -1,0 +1,28 @@
+﻿using BeatSaberMarkupLanguage.Settings;
+using BeatSaberMarkupLanguage.Util;
+using DiscordCore.UI;
+
+namespace DiscordCore
+{
+    internal class SettingsMenuManager
+    {
+        private static bool DidInit { get; set; } = false;
+
+        private const string MenuName = "Discord Core";
+        private const string ResourcePath = "DiscordCore.UI.SettingsViewController.bsml";
+
+        public static void Initialize()
+        {
+            if (!DidInit)
+            {
+                MainMenuAwaiter.MainMenuInitializing += InitOnMainMenuLoaded;
+                DidInit = true;
+            }
+        }
+
+        private static void InitOnMainMenuLoaded()
+        {
+            BSMLSettings.Instance.AddSettingsMenu(MenuName, ResourcePath, Settings.instance);
+        }
+    }
+}

--- a/UI/SettingsViewController.bsml
+++ b/UI/SettingsViewController.bsml
@@ -1,4 +1,4 @@
-﻿<settings-container>
+﻿<settings-container xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://monkeymanboy.github.io/BSML-Docs/BSMLSchema.xsd'>
 
   <checkbox text='Enable DiscordCore' value='enable-plugin' apply-on-change='true' />
   <checkbox text='Allow join requests' value='allow-join' apply-on-change='true' />
@@ -16,10 +16,10 @@
           <text id='mod-name' align='MidlineLeft' font-size='5' />
         </horizontal>
 
-        <horizontal child-expand-width='true' vertical-fit='Unconstrained' horizontal-fit='PreferredSize' spacing='1'>
-          <page-button dir='Up' on-click='increase-priority' pref-width='8'/>
-          <page-button dir='Down' on-click='decrease-priority' pref-width='8'/>
+        <horizontal background='round-rect-panel' vertical-fit='Unconstrained' horizontal-fit='PreferredSize' spacing='1'>
           <checkbox text='' value='enable-mod' apply-on-change='true' on-change='active-state-changed' pref-width='6'/>
+          <page-button dir='Up' on-click='increase-priority' pref-width='5'/>
+          <page-button dir='Down' on-click='decrease-priority' pref-width='5'/>
         </horizontal>
       </horizontal>
 


### PR DESCRIPTION
- BSML menus need to be created after the menu scene loads, the `SettingsMenuManager` uses a BSML event to do this
- Altered the list so the buttons no longer overlap
- Hide the image if there is no image